### PR TITLE
fix attack button display bug at end of enemy defeat

### DIFF
--- a/javascript/game.js
+++ b/javascript/game.js
@@ -57,7 +57,9 @@ $(document).ready(function() {
         }
         setTimeout(function () {
             $("#enemy-message").html("");
-            $("#attack-button").show();
+            if (enemyHP > 0) {
+                $("#attack-button").show();
+            }
         }, 3000)
 
     }


### PR DESCRIPTION
Upon adding the dark mode button, I realized the Attack button would incorrectly appear beneath the "Continue" button after an enemy was defeated. (It's always been doing this, but I wasn't scrolling down beneath the fold to ever notice it before.) I added an if statement to check if the enemy is still alive before displaying the attack button on the 3-second setTimeout function.